### PR TITLE
Add Sorting Order to BeatmapLoader

### DIFF
--- a/Rhythm Game 168/Assets/Scenes/Debug/Dien_Debug.unity
+++ b/Rhythm Game 168/Assets/Scenes/Debug/Dien_Debug.unity
@@ -677,6 +677,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5031095185751185402, guid: fa70149573acee54ab8235bd116875ec, type: 3}
+      propertyPath: sortingOrder
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fa70149573acee54ab8235bd116875ec, type: 3}
 --- !u!1001 &1170942503

--- a/Rhythm Game 168/Assets/Scripts/Gameplay/BeatmapLoader.cs
+++ b/Rhythm Game 168/Assets/Scripts/Gameplay/BeatmapLoader.cs
@@ -7,6 +7,7 @@ public class BeatmapLoader : MonoBehaviour
 {
     [SerializeField] private string beatMapName;
     [SerializeField] private GameObject notePrefab;
+    [SerializeField] private int sortingOrder;
 
     void Start()
     {
@@ -52,6 +53,7 @@ public class BeatmapLoader : MonoBehaviour
             {
                 GameObject note = Instantiate(notePrefab, Vector3.zero, rotation, transform);
                 note.transform.localPosition = new Vector3(receiverPos, pos, 0f);
+                note.GetComponent<SpriteRenderer>().sortingOrder = sortingOrder;
             }
         }
         Debug.Log("LOADED BEATMAP " + beatMapName + " from " + Application.dataPath + "/Beatmap/" + beatMapName + ".json");


### PR DESCRIPTION
All notes spawn from beatmap will have the same sorting order